### PR TITLE
SUPER-CHIP (v0.2)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # configure.ac
 
-AC_INIT([chip8], [0.1.3], [danirod@outlook.com])
+AC_INIT([chip8], [0.2.0], [danirod@outlook.com])
 AM_INIT_AUTOMAKE([foreign -Wall -Werror])
 
 # Check programs

--- a/doc/schip8.txt
+++ b/doc/schip8.txt
@@ -1,0 +1,134 @@
+SCHIP SPECIFICATION
+Author: Dani Rodríguez <danirod@outlook.com>
+Creative Commons 3.0 Attribution - Non Commercial - Share Alike
+
+
+1. INTRODUCTION
+===============
+SCHIP (also known as SUPER-CHIP) is an extened specification designed over the
+original CHIP-8 specification made in the 70s. Initially designed for HP48
+calculators, it has the following features:
+
+* A new extended screen display mode with bigger resolution (128x64).
+* Instructions for scrolling the screen downards, leftwards and rightwards.
+* Emulation can be stopped from game using the EXIT instruction.
+* Bigger font digits (10 bytes, instead of the usual 5 bytes per digit).
+* Information can be exchanged between emulator and underlying platform.
+
+SCHIP is designed so that SCHIP emulators are backwards compatible with CHIP-8
+games. It is possible to run a CHIP-8 game on a SCHIP emulator because SCHIP
+instructions uses free spaces found in the original CHIP-8 instruction set.
+
+
+2. EXTENDED SCREEN MODE
+=======================
+Extended screen mode is a feature part of SCHIP. On extended screen mode, the
+screen resolution is upgraded to 128x64 pixels wide, plus the emulator gains
+the ability to render 16x16 sprites, in contrast to 8x16 sprites like CHIP-8
+can.
+
+In order to keep compatibility with original CHIP-8 games, extended screen
+game is not enabled by default. This means: SCHIP emulators also start in
+64x32 mode. However, it is possible to enable Extended Screen Mode by
+executing a special opcode that triggers extended screen mode.
+
+* By triggering HIGH instruction, the emulator should enter extended screen
+  mode. The resolution should change to 128x64 and the emulator should
+  remember the new state for the DRAW opcode.
+* By triggering LOW instruction, the emulator should leave extended screen
+  mode. The resolution should go back to 64x32 and the emulator should
+  not remember the state anymore.
+
+
+3. SPRITE RENDERING
+===================
+SCHIP provides an aditional rendering mode modifying how the DRAW
+instruction works. Thanks to these changes it is possible to render 16x16
+sprites.
+
+If the DRAW instruction is executed with N=0 and extended display is enabled,
+then I points to a 16x16 sprite structure that should be rendered at the
+location given in Vx, Vy.
+
+The sprite is encoded as a series of 16 rows, each row being 16 bits wide.
+So, the sprite is 32 bytes. Just like in the original CHIP-8, bytes in the
+lowest addresses are rendered in smaller Y values (they appear on top).
+Also, SCHIP seems to be big-endian, so MSB bits in each row are rendered
+leftside.
+
+
+4. BIGGER FONTS
+===============
+SCHIP provides 10 row digit sprites (10-byte sprites). Executing the LDHF
+instruction will make the I register point to the memory address where one
+of these sprites is located in. It is possible to render the sprite later
+using the DRAW instruction.
+
+At the moment I haven't found any reference digit sprites. So I guess that
+this is up to the emulator developer to use the sprite font they want.
+
+
+5. SCREEN SCROLLING
+===================
+There are three instructions designed for scrolling the window: moving the
+pixels to one or other side, depending on the executed instruction.
+
+* SCD: this instruction scrolls the screen down. The number of lines the
+  screen should be scrolled down is given as argument N: 0x00CN.
+* SCR: this instruction scrolls the screen 4 pixels to the right.
+* SCL: this instruction scrolls the screen 4 pixels to the left.
+
+
+6. USER FLAGS
+=============
+This feature provides 8 aditional flags to the SCHIP emulator. In the
+original SCHIP implementation made for the HP 48 series calculator, the
+registers were also used by the RPL programming language; which means that
+the data from this registers could be inputed via RPL before running the
+emulator; and the values in this registers after the emulation could be
+later accessed via RPL. It is not clear how could this be emulated in other
+platforms.
+
+The LD R, Vx and LD Vx, R instructions let the user store registers V0 to Vx
+in the R registers. Because the RPL only had 8 registers, it is only
+possible to store from V0 up to V7.
+
+
+7. OPCODES REFERENCE
+====================
+SCD     00CN    Scrolls the screen down.
+SCR     00FB    Scrolls the screen to the right.
+SCL     00FC    Scrolls the screen to the left.
+EXIT    00FD    Exits CHIP8 interpreter.
+LOW     00FE    Disables extended screen mode.
+HIGH    00FF    Enables extended screen mode.
+DRAW    DXYN    Render sprite (using SCHIP capabilities).
+LDHF    FX30    Points I to a 10-byte font sprite.
+LDRV    FX75    Store V0..VX (X <= 7) in RPL user flags.
+LDVR    FX85    Read V0..VX (X <= 7) from RPL user flags.
+
+
+8. EXAMPLE ASSEMBLY INSTRUCTIONS
+================================
+
+    SCD 6           ; Scroll the screen 6 pixels down.
+    SCR             ; Scroll the screen to the right.
+    SCL             ; Scroll the screen to the left.
+    EXIT            ; Stop the emulation.
+    LOW             ; Leave extended screen mode.
+    HIGH            ; Enter extended screen mode.
+    DRAW V5, V4, 0  ; Draw the 16x16 bit sprite at [5][4].
+    LD HF, V3       ; Make I point to the digit located in V3.
+    LD R, V7        ; Store registers V0 to V7 in R.
+    LD V5, R        ; read registers V0 to V5 from R.
+        
+
+9. ADITIONAL RESOURCES
+===================
+* https://groups.google.com/d/msg/comp.sys.handhelds/RuzVNccds2Q/TcvLEWuY9scJ
+* https://groups.google.com/d/msg/comp.sys.handhelds/sDY9zFb6KUo/JcYBK2_yerMJ
+* http://devernay.free.fr/hacks/chip8/C8TECH10.HTM
+* http://devernay.free.fr/hacks/chip8/schip.txt
+* http://www.chip8.com/?page=82
+* http://www.chip8.com/?page=89
+* http://www.chip8.com/?page=85

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -32,12 +32,16 @@ static int use_hexloader;
 /* Flag set by '--mute' */
 static int use_mute;
 
+/* Flag used by '--debug' */
+static int use_debug;
+
 /* getopt parameter structure. */
 static struct option long_options[] = {
     { "help", no_argument, 0, 'h' },
     { "version", no_argument, 0, 'v' },
     { "hex", no_argument, &use_hexloader, 1 },
     { "mute", no_argument, &use_mute, 1 },
+    { "debug", no_argument, &use_debug, 1 },
     { 0, 0, 0, 0 }
 };
 
@@ -208,6 +212,9 @@ main(int argc, char** argv)
 
     /* Init emulator. */
     srand(time(NULL));
+    if (use_debug) {
+        set_debug_mode(1);
+    }
     init_machine(&mac);
     mac.keydown = &is_key_down;
     if (!use_mute) {

--- a/src/chip8.c
+++ b/src/chip8.c
@@ -23,6 +23,7 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 /* Flag set by '--hex' */

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -418,6 +418,9 @@ init_machine(struct machine_t* machine)
 void
 step_machine(struct machine_t* cpu)
 {
+    if (cpu->exit)
+        return;
+
     /* Are we waiting for a key press? */
     if (cpu->wait_key != -1 && cpu->keydown) {
         for (int i = 0; i < 16; i++) {

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -364,3 +364,69 @@ update_time(struct machine_t* cpu, int delta)
         }
     }
 }
+
+void
+screen_fill_column(struct machine_t* cpu, int column)
+{
+    int rowsiz = cpu->esm ? 128 : 64;
+    int limit = cpu->esm ? 64 : 32;
+    for (int y = 0; y < limit; y++) {
+        cpu->screen[rowsiz * y + column] = 1;
+    }
+}
+
+void
+screen_clear_column(struct machine_t* cpu, int column)
+{
+    int rowsiz = cpu->esm ? 128 : 64;
+    int limit = cpu->esm ? 64 : 32;
+    for (int y = 0; y < limit; y++) {
+        cpu->screen[rowsiz * y + column] = 0;
+    }
+}
+
+void
+screen_fill_row(struct machine_t* cpu, int row)
+{
+    int colsiz = cpu->esm ? 64 : 32;
+    int limit = cpu->esm ? 128 : 64;
+    int rowsiz = limit;
+    for (int x = 0; x < limit; x++) {
+        cpu->screen[rowsiz * row + x] = 1;
+    }
+}
+
+void
+screen_clear_row(struct machine_t* cpu, int row)
+{
+    int colsiz = cpu->esm ? 64 : 32;
+    int limit = cpu->esm ? 128 : 64;
+    int rowsiz = limit;
+    for (int x = 0; x < limit; x++) {
+        cpu->screen[rowsiz * row + x] = 0;
+    }
+}
+
+int
+screen_get_pixel(struct machine_t* cpu, int row, int column)
+{
+    int colsiz = cpu->esm ? 64 : 32;
+    int rowsiz = cpu->esm ? 128 : 64;
+    return cpu->screen[rowsiz * row + column] != 0;
+}
+
+void
+screen_set_pixel(struct machine_t* cpu, int row, int column)
+{
+    int colsiz = cpu->esm ? 64 : 32;
+    int rowsiz = cpu->esm ? 128 : 64;
+    cpu->screen[rowsiz * row + column] = 1;
+}
+
+void
+screen_clear_pixel(struct machine_t* cpu, int row, int column)
+{
+    int colsiz = cpu->esm ? 64 : 32;
+    int rowsiz = cpu->esm ? 128 : 64;
+    cpu->screen[rowsiz * row + column] = 0;
+}

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -65,7 +65,7 @@ nibble_0(struct machine_t* cpu, word opcode)
         int colsiz = cpu->esm ? 64 : 32;
         int n = OPCODE_N(opcode);
         int start_row = 0, last_row = colsiz - n - 1;
-        for (int row = last_row; row <= start_row; row--) {
+        for (int row = last_row; row >= start_row; row--) {
             for (int x = 0; x < rowsiz; x++) {
                 int from = row * rowsiz + x;
                 int to = (row + n) * rowsiz + x;
@@ -80,6 +80,30 @@ nibble_0(struct machine_t* cpu, word opcode)
         if (cpu->sp > 0)
         cpu->pc = cpu->stack[(int) --cpu->sp];
         /* TODO: Should throw an error on stack underflow. */
+    } else if (opcode == 0x00fb) {
+        /* 00FB: SCR - Scroll 4 pixels to the right. */
+        int rowsiz = cpu->esm ? 128 : 64;
+        int colsiz = cpu->esm ? 64 : 32;
+        int start_col = 0, last_col = rowsiz - 4 - 1;
+        for (int col = last_col; col >= start_col; col--) {
+            for (int y = 0; y < colsiz; y++) {
+                int from = y * rowsiz + col;
+                int to = y * rowsiz + (4 + col);
+                cpu->screen[to] = cpu->screen[from];
+            }
+        }
+    } else if (opcode == 0x00fc) {
+        /* 00FC: SCL - Scroll 4 pixels to the left. */
+        int rowsiz = cpu->esm ? 128 : 64;
+        int colsiz = cpu->esm ? 64 : 32;
+        int start_col = 4, last_col = rowsiz - 1;
+        for (int col = start_col; col <= last_col; col++) {
+            for (int y = 0; y < colsiz; y++) {
+                int from = y * rowsiz + col;
+                int to = y * rowsiz + (col - 4);
+                cpu->screen[to] = cpu->screen[from];
+            }
+        }
     } else if (opcode == 0x00fd) {
         /* 00FD: EXIT - Stop emulator. */
         cpu->exit = 1;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -67,6 +67,15 @@ nibble_0(struct machine_t* cpu, word opcode)
         if (cpu->sp > 0)
         cpu->pc = cpu->stack[(int) --cpu->sp];
         /* TODO: Should throw an error on stack underflow. */
+    } else if (opcode == 0x00fd) {
+        /* 00FD: EXIT - Stop emulator. */
+        cpu->exit = 1;
+    } else if (opcode == 0x00fe) {
+        /* 00FE: LOW - Disable extended screen mode. */
+        cpu->esm = 0;
+    } else if (opcode == 0x00ff) {
+        /* 00FF: HIGH - Enable extended scren mode. */
+        cpu->esm = 1;
     }
 }
 
@@ -388,7 +397,6 @@ screen_clear_column(struct machine_t* cpu, int column)
 void
 screen_fill_row(struct machine_t* cpu, int row)
 {
-    int colsiz = cpu->esm ? 64 : 32;
     int limit = cpu->esm ? 128 : 64;
     int rowsiz = limit;
     for (int x = 0; x < limit; x++) {
@@ -399,7 +407,6 @@ screen_fill_row(struct machine_t* cpu, int row)
 void
 screen_clear_row(struct machine_t* cpu, int row)
 {
-    int colsiz = cpu->esm ? 64 : 32;
     int limit = cpu->esm ? 128 : 64;
     int rowsiz = limit;
     for (int x = 0; x < limit; x++) {
@@ -410,7 +417,6 @@ screen_clear_row(struct machine_t* cpu, int row)
 int
 screen_get_pixel(struct machine_t* cpu, int row, int column)
 {
-    int colsiz = cpu->esm ? 64 : 32;
     int rowsiz = cpu->esm ? 128 : 64;
     return cpu->screen[rowsiz * row + column] != 0;
 }
@@ -418,7 +424,6 @@ screen_get_pixel(struct machine_t* cpu, int row, int column)
 void
 screen_set_pixel(struct machine_t* cpu, int row, int column)
 {
-    int colsiz = cpu->esm ? 64 : 32;
     int rowsiz = cpu->esm ? 128 : 64;
     cpu->screen[rowsiz * row + column] = 1;
 }
@@ -426,7 +431,6 @@ screen_set_pixel(struct machine_t* cpu, int row, int column)
 void
 screen_clear_pixel(struct machine_t* cpu, int row, int column)
 {
-    int colsiz = cpu->esm ? 64 : 32;
     int rowsiz = cpu->esm ? 128 : 64;
     cpu->screen[rowsiz * row + column] = 0;
 }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -260,11 +260,16 @@ nibble_D(struct machine_t* cpu, word opcode)
     cpu->v[15] = 0;
     if (cpu->esm && OPCODE_N(opcode) == 0) {
         for (int j = 0; j < 16; j++) {
-            word sprite = cpu->mem[cpu->i + 2 * j];
+            // Sprite to plot on this line.
+            byte hi = cpu->mem[cpu->i + 2 * j];
+            byte lo = cpu->mem[cpu->i + 2 * j + 1];
+            word sprite = hi << 8 | lo;
             for (int i = 0; i < 16; i++) {
+                // Where to plot at.
                 int px = (cpu->v[x] + i) & 127;
                 int py = (cpu->v[y] + j) & 63;
                 int pos = 128 * py + px;
+                // What to plot.
                 int pixel = (sprite & (1 << (15-i))) != 0;
                 cpu->v[15] |= (cpu->screen[pos] & pixel);
                 cpu->screen[pos] ^= pixel;

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -19,6 +19,7 @@
 #include "cpu.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 #define OPCODE_NNN(opcode) (opcode & 0xFFF)
 #define OPCODE_KK(opcode) (opcode & 0xFF)
@@ -26,6 +27,21 @@
 #define OPCODE_X(opcode) ((opcode >> 8) & 0xF)
 #define OPCODE_Y(opcode) ((opcode >> 4) & 0xF)
 #define OPCODE_P(opcode) (opcode >> 12)
+
+static int is_debug = 0;
+
+static void
+log(const char* msg)
+{
+    if (is_debug) {
+        printf("MESSAGE: %s\n", msg);
+    }
+}
+
+void
+set_debug_mode(int debug_mode) {
+    is_debug = debug_mode;
+}
 
 /**
  * These are the bitmaps for the sprites that represent numbers.
@@ -395,9 +411,9 @@ init_machine(struct machine_t* machine)
     machine->pc = 0x200;
     machine->wait_key = -1;
     global_delta = 0;
+    log("Debug mode is enabled");
+    log("Machine has been initialized");
 }
-
-#include <stdio.h>
 
 void
 step_machine(struct machine_t* cpu)
@@ -422,6 +438,10 @@ step_machine(struct machine_t* cpu)
     /* Fetch next opcode. */
     word opcode = (cpu->mem[cpu->pc] << 8) | cpu->mem[cpu->pc + 1];
     cpu->pc = (cpu->pc + 2) & 0xFFF;
+
+    if (is_debug) {
+        printf("Executing opcode 0x%x...\n", opcode);
+    }
 
     /* Execute the corresponding handler from the nibble table. */
     nibbles[OPCODE_P(opcode)](cpu, opcode);

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -125,4 +125,6 @@ void screen_set_pixel(struct machine_t* cpu, int row, int column);
 
 void screen_clear_pixel(struct machine_t* cpu, int row, int column);
 
+void set_debug_mode(int mode);
+
 #endif // CPU_H_

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -73,11 +73,14 @@ struct machine_t
     address i;                 // Special I register
     byte dt, st;             // Timers
 
-    char screen[2048];          // Screen bitmap
+    char screen[8192];          // Screen bitmap
     char wait_key;              // Key the CHIP-8 is idle waiting for.
 
     keyboard_poller_t keydown; // Keyboard poller
     speaker_handler_t speaker; // Speaker handler
+
+    int exit;                   // Should close the game.
+    int esm;                    // Is in Extended Screen Mode? 
 };
 
 /**
@@ -106,5 +109,19 @@ void step_machine(struct machine_t* cpu);
  * @param delta amount of milliseconds since last call to function.
  */
 void update_time(struct machine_t* cpu, int delta);
+
+void screen_fill_column(struct machine_t* cpu, int column);
+
+void screen_clear_column(struct machine_t* cpu, int column);
+
+void screen_fill_row(struct machine_t* cpu, int row);
+
+void screen_clear_row(struct machine_t* cpu, int row);
+
+int screen_get_pixel(struct machine_t* cpu, int row, int column);
+
+void screen_set_pixel(struct machine_t* cpu, int row, int column);
+
+void screen_clear_pixel(struct machine_t* cpu, int row, int column);
 
 #endif // CPU_H_

--- a/src/cpu.h
+++ b/src/cpu.h
@@ -81,6 +81,7 @@ struct machine_t
 
     int exit;                   // Should close the game.
     int esm;                    // Is in Extended Screen Mode? 
+    byte r[8];                  // R register set.
 };
 
 /**

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 TESTS = chip8_test
 check_PROGRAMS = chip8_test
-chip8_test_SOURCES = test.c opcodes.c
+chip8_test_SOURCES = test.c opchip.c
 chip8_test_CFLAGS = -std=c99 -Wall @CHECK_CFLAGS@
 chip8_test_LDADD = @CHECK_LIBS@ ../src/lib8.a

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 TESTS = chip8_test
 check_PROGRAMS = chip8_test
-chip8_test_SOURCES = test.c opchip.c
+chip8_test_SOURCES = test.c opchip.c opschip.c
 chip8_test_CFLAGS = -std=c99 -Wall @CHECK_CFLAGS@
 chip8_test_LDADD = @CHECK_LIBS@ ../src/lib8.a

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 TESTS = chip8_test
 check_PROGRAMS = chip8_test
-chip8_test_SOURCES = test.c opchip.c opschip.c
+chip8_test_SOURCES = test.c opchip.c opschip.c screen.c
 chip8_test_CFLAGS = -std=c99 -Wall @CHECK_CFLAGS@
 chip8_test_LDADD = @CHECK_LIBS@ ../src/lib8.a

--- a/tests/opchip.c
+++ b/tests/opchip.c
@@ -16,6 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
+ * File: tests/opchip.c
+ * Description: Unit test related to CHIP-8 Opcodes.
+ */
+
 #include <check.h>
 #include <stdint.h>
 #include "../src/cpu.h"
@@ -779,9 +784,9 @@ tcase_ldix()
 }
 
 Suite*
-create_opcodes_suite()
+create_chip8_opcodes_suite()
 {
-    Suite* suite = suite_create("Opcodes");
+    Suite* suite = suite_create("CHIP-8 Opcodes");
     suite_add_tcase(suite, tcase_cls());
     suite_add_tcase(suite, tcase_rts());
     suite_add_tcase(suite, tcase_jmp());

--- a/tests/opschip.c
+++ b/tests/opschip.c
@@ -53,7 +53,7 @@ START_TEST(test_scd)
 {
     /* Clear the screen, but put an horizontal line on Y = 0. */
     memset(cpu.screen, 0, 2048);
-    screen_fill_row(cpu.screen, 0);
+    screen_fill_row(&cpu, 0);
 
     /* Execute SCD 4. */
     cpu.pc = 0x200;
@@ -65,9 +65,9 @@ START_TEST(test_scd)
     for (int x = 0; x < 64; x++) {
         for (int y = 0; y < 64; y++) {
             if (y == 4) {
-                ck_assert_int_ne(0, screen_get_pixel(cpu.screen, x, y));
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
             } else {
-                ck_assert_int_eq(0, screen_get_pixel(cpu.screen, x, y));
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
             }
         }
     }
@@ -87,7 +87,7 @@ START_TEST(test_scr)
 {
     /* Clear the screen and put a vertical line on X = 0; */
     memset(cpu.screen, 0, 2048);
-    screen_fill_column(cpu.screen, 0);
+    screen_fill_column(&cpu, 0);
     
     /* Execute SCR. */
     cpu.pc = 0x200;
@@ -99,9 +99,9 @@ START_TEST(test_scr)
     for (int x = 0; x < 64; x++) {
         for (int y = 0; y < 64; y++) {
             if (x == 4) {
-                ck_assert_int_ne(0, screen_get_pixel(cpu.screen, x, y));
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
             } else {
-                ck_assert_int_eq(0, screen_get_pixel(cpu.screen, x, y));
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
             }
         }
     }
@@ -121,7 +121,7 @@ START_TEST(test_scl)
 {
     /* Clear the screen and put a vertical line on X = 0; */
     memset(cpu.screen, 0, 2048);
-    screen_fill_column(cpu.screen, 4);
+    screen_fill_column(&cpu, 4);
     
     /* Execute SCL. */
     cpu.pc = 0x200;
@@ -133,9 +133,9 @@ START_TEST(test_scl)
     for (int x = 0; x < 64; x++) {
         for (int y = 0; y < 64; y++) {
             if (x == 0) {
-                ck_assert_int_ne(0, screen_get_pixel(cpu.screen, x, y));
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
             } else {
-                ck_assert_int_eq(0, screen_get_pixel(cpu.screen, x, y));
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
             }
         }
     }
@@ -230,9 +230,9 @@ START_TEST(test_draw_esm)
     for (int y = 0; y < 64; y++) {
         for (int x = 0; x < 128; x++) {
             if (x < 16 && y < 16) {
-                ck_assert_int_ne(0, screen_get_pixel(cpu.screen, x, y));
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
             } else {
-                ck_assert_int_eq(0, screen_get_pixel(cpu.screen, x, y));
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
             }
         }
     }
@@ -246,4 +246,14 @@ tcase_draw_esm()
     TCase* tcase = setup_tcase("DRW ESM");
     tcase_add_test(tcase, test_draw_esm);
     return tcase;
+}
+
+Suite*
+create_superchip_opcodes_suite()
+{
+    Suite* suite = suite_create("SCHIP Opcodes");
+    suite_add_tcase(suite, tcase_exit());
+    suite_add_tcase(suite, tcase_high());
+    suite_add_tcase(suite, tcase_low());
+    return suite;
 }

--- a/tests/opschip.c
+++ b/tests/opschip.c
@@ -309,18 +309,19 @@ START_TEST(test_draw_esm)
 
     /* Set up machine. */
     cpu.esm = 1;
-    memset(cpu.screen, 0, sizeof (cpu.screen));
-    cpu.pc = 0x200;
+    memset(cpu.screen, 0, 8192);
+    cpu.i = 0x800;
     put_opcode(0xD110, 0x200);
     step_machine(&cpu);
 
     /* Check that the sprite is drawn. */
-    for (int y = 0; y < 64; y++) {
-        for (int x = 0; x < 128; x++) {
-            if (x < 16 && y < 16) {
-                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
+    ck_assert_int_eq(0x202, cpu.pc);
+    for (int row = 0; row < 64; row++) {
+        for (int col = 0; col < 128; col++) {
+            if (row < 16 && col < 16) {
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, row, col));
             } else {
-                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, row, col));
             }
         }
     }

--- a/tests/opschip.c
+++ b/tests/opschip.c
@@ -1,0 +1,249 @@
+/*
+ * chip8 is a CHIP-8 emulator done in C
+ * Copyright (C) 2015-2016 Dani Rodríguez <danirod@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * File: tests/opschip.c
+ * Description: Unit test related to SUPER-CHIP Opcodes.
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include "../src/cpu.h"
+
+struct machine_t cpu;
+
+static void
+setup_cpu(void)
+{
+    init_machine(&cpu);
+}
+
+static TCase*
+setup_tcase(char* name)
+{
+    TCase* tcase = tcase_create(name);
+    tcase_add_checked_fixture(tcase, setup_cpu, NULL);
+    return tcase;
+}
+
+static void
+put_opcode(word opcode, address pos)
+{
+    cpu.mem[pos] = opcode >> 8;
+    cpu.mem[pos + 1] = opcode & 0xFF;
+}
+
+/* Executing SCD should scroll the screen N pixels down. */
+START_TEST(test_scd)
+{
+    /* Clear the screen, but put an horizontal line on Y = 0. */
+    memset(cpu.screen, 0, 2048);
+    screen_fill_row(cpu.screen, 0);
+
+    /* Execute SCD 4. */
+    cpu.pc = 0x200;
+    put_opcode(0x00C4, 0x200);
+    step_machine(&cpu);
+
+    /* Test execution. */
+    ck_assert_int_eq(0x202, cpu.pc);
+    for (int x = 0; x < 64; x++) {
+        for (int y = 0; y < 64; y++) {
+            if (y == 4) {
+                ck_assert_int_ne(0, screen_get_pixel(cpu.screen, x, y));
+            } else {
+                ck_assert_int_eq(0, screen_get_pixel(cpu.screen, x, y));
+            }
+        }
+    }
+}
+END_TEST
+
+static TCase*
+tcase_scd()
+{
+    TCase* tcase = setup_tcase("SCD");
+    tcase_add_test(tcase, test_scd);
+    return tcase;
+}
+
+/* Executing SCR should scroll the screen 4 pixels to the right. */
+START_TEST(test_scr)
+{
+    /* Clear the screen and put a vertical line on X = 0; */
+    memset(cpu.screen, 0, 2048);
+    screen_fill_column(cpu.screen, 0);
+    
+    /* Execute SCR. */
+    cpu.pc = 0x200;
+    put_opcode(0x00FB, 0x200);
+    step_machine(&cpu);
+
+    /* Test execution. */
+    ck_assert_int_eq(0x202, cpu.pc);
+    for (int x = 0; x < 64; x++) {
+        for (int y = 0; y < 64; y++) {
+            if (x == 4) {
+                ck_assert_int_ne(0, screen_get_pixel(cpu.screen, x, y));
+            } else {
+                ck_assert_int_eq(0, screen_get_pixel(cpu.screen, x, y));
+            }
+        }
+    }
+}
+END_TEST
+
+static TCase*
+tcase_scr()
+{
+    TCase* tcase = setup_tcase("SCR");
+    tcase_add_test(tcase, test_scr);
+    return tcase;
+}
+
+/* Executing SCL should scroll the screen 4 pixels to the left. */
+START_TEST(test_scl)
+{
+    /* Clear the screen and put a vertical line on X = 0; */
+    memset(cpu.screen, 0, 2048);
+    screen_fill_column(cpu.screen, 4);
+    
+    /* Execute SCL. */
+    cpu.pc = 0x200;
+    put_opcode(0x00FC, 0x200);
+    step_machine(&cpu);
+
+    /* Test execution. */
+    ck_assert_int_eq(0x202, cpu.pc);
+    for (int x = 0; x < 64; x++) {
+        for (int y = 0; y < 64; y++) {
+            if (x == 0) {
+                ck_assert_int_ne(0, screen_get_pixel(cpu.screen, x, y));
+            } else {
+                ck_assert_int_eq(0, screen_get_pixel(cpu.screen, x, y));
+            }
+        }
+    }
+}
+END_TEST
+
+static TCase*
+tcase_scl()
+{
+    TCase* tcase = setup_tcase("SCL");
+    tcase_add_test(tcase, test_scl);
+    return tcase;
+}
+
+/* Executing EXIT should set the exit flag to true. */
+START_TEST(test_exit)
+{
+    cpu.exit = 0;
+    cpu.pc = 0x200;
+    put_opcode(0x00FD, 0x200);
+    step_machine(&cpu);
+    ck_assert_int_eq(0x202, cpu.pc);
+    ck_assert_int_ne(0, cpu.exit);
+}
+END_TEST
+
+static TCase*
+tcase_exit()
+{
+    TCase* tcase = setup_tcase("EXIT");
+    tcase_add_test(tcase, test_exit);
+    return tcase;
+}
+
+/* Executing LOW should disable extended screen mode. */
+START_TEST(test_low)
+{
+    cpu.esm = 1;
+    cpu.pc = 0x200;
+    put_opcode(0x00FE, 0x200);
+    step_machine(&cpu);
+    ck_assert_int_eq(0x202, cpu.pc);
+    ck_assert_int_eq(0, cpu.esm);
+}
+END_TEST
+
+static TCase*
+tcase_low()
+{
+    TCase* tcase = setup_tcase("LOW");
+    tcase_add_test(tcase, test_low);
+    return tcase;
+}
+
+/* Executing HIGH should enable extended screen mode. */
+START_TEST(test_high)
+{
+    cpu.esm = 0;
+    cpu.pc = 0x200;
+    put_opcode(0x00FF, 0x200);
+    step_machine(&cpu);
+    ck_assert_int_eq(0x202, cpu.pc);
+    ck_assert_int_ne(0, cpu.esm);
+}
+END_TEST
+
+static TCase*
+tcase_high()
+{
+    TCase* tcase = setup_tcase("HIGH");
+    tcase_add_test(tcase, test_high);
+    return tcase;
+}
+
+/* Executing DRAW with extended mode should render a 16x16 sprite. */
+START_TEST(test_draw_esm)
+{
+    /* Set up sprite. */
+    for (int i = 0; i < 32; i++) {
+        cpu.mem[0x800 + i] = 0xFF;
+    }
+
+    /* Set up machine. */
+    cpu.esm = 1;
+    memcpy(cpu.screen, 0, 8192);
+    cpu.pc = 0x200;
+    put_opcode(0xD110, 0x200);
+
+    step_machine(&cpu);
+
+    /* Check that the sprite is drawn. */
+    for (int y = 0; y < 64; y++) {
+        for (int x = 0; x < 128; x++) {
+            if (x < 16 && y < 16) {
+                ck_assert_int_ne(0, screen_get_pixel(cpu.screen, x, y));
+            } else {
+                ck_assert_int_eq(0, screen_get_pixel(cpu.screen, x, y));
+            }
+        }
+    }
+    ck_assert_int_eq(0x202, cpu.pc);
+}
+END_TEST
+
+static TCase*
+tcase_draw_esm()
+{
+    TCase* tcase = setup_tcase("DRW ESM");
+    tcase_add_test(tcase, test_draw_esm);
+    return tcase;
+}

--- a/tests/opschip.c
+++ b/tests/opschip.c
@@ -62,12 +62,12 @@ START_TEST(test_scd)
 
     /* Test execution. */
     ck_assert_int_eq(0x202, cpu.pc);
-    for (int x = 0; x < 64; x++) {
-        for (int y = 0; y < 64; y++) {
-            if (y == 4) {
-                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
+    for (int row = 0; row < 32; row++) {
+        for (int col = 0; col < 64; col++) {
+            if (row == 0 || row == 4) {
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, row, col));
             } else {
-                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, row, col));
             }
         }
     }
@@ -96,12 +96,12 @@ START_TEST(test_scr)
 
     /* Test execution. */
     ck_assert_int_eq(0x202, cpu.pc);
-    for (int x = 0; x < 64; x++) {
-        for (int y = 0; y < 64; y++) {
-            if (x == 4) {
-                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
+    for (int row = 0; row < 32; row++) {
+        for (int col = 0; col < 64; col++) {
+            if (col == 0 || col == 4) {
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, row, col));
             } else {
-                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, row, col));
             }
         }
     }
@@ -130,12 +130,12 @@ START_TEST(test_scl)
 
     /* Test execution. */
     ck_assert_int_eq(0x202, cpu.pc);
-    for (int x = 0; x < 64; x++) {
-        for (int y = 0; y < 64; y++) {
-            if (x == 0) {
-                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
+    for (int row = 0; row < 32; row++) {
+        for (int col = 0; col < 64; col++) {
+            if (col == 0) {
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, row, col));
             } else {
-                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, row, col));
             }
         }
     }

--- a/tests/screen.c
+++ b/tests/screen.c
@@ -1,0 +1,233 @@
+/*
+ * chip8 is a CHIP-8 emulator done in C
+ * Copyright (C) 2015-2016 Dani Rodríguez <danirod@outlook.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * File: tests/screen.c
+ * Description: Unit test related to screen management.
+ */
+
+#include <check.h>
+#include <stdint.h>
+#include "../src/cpu.h"
+
+struct machine_t cpu;
+
+static void
+setup_cpu(void)
+{
+    init_machine(&cpu);
+}
+
+static TCase*
+setup_tcase(char* name)
+{
+    TCase* tcase = tcase_create(name);
+    tcase_add_checked_fixture(tcase, setup_cpu, NULL);
+    return tcase;
+}
+
+START_TEST(test_screen_fill_column)
+{
+    cpu.esm = 0;
+    memset(cpu.screen, 0, sizeof (cpu.screen));
+    screen_fill_column(&cpu, 4);
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 64; x++) {
+            if (x == 4) {
+                ck_assert_int_ne(0, cpu.screen[64 * y + x]);
+            } else {
+                ck_assert_int_eq(0, cpu.screen[64 * y + x]);
+            }
+        }
+    }
+}
+END_TEST
+
+START_TEST(test_screen_clear_column)
+{
+    cpu.esm = 0;
+    memset(cpu.screen, 1, sizeof (cpu.screen));
+    screen_clear_column(&cpu, 8);
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 64; x++) {
+            if (x == 8) {
+                ck_assert_int_eq(0, cpu.screen[64 * y + x]);
+            } else {
+                ck_assert_int_ne(0, cpu.screen[64 * y + x]);
+            }
+        }
+    }
+}
+END_TEST
+
+START_TEST(test_screen_fill_row)
+{
+    cpu.esm = 0;
+    memset(cpu.screen, 0, sizeof(cpu.screen));
+    screen_fill_row(&cpu, 4);
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 64; x++) {
+            if (y == 4) {
+                ck_assert_int_ne(0, cpu.screen[64 * y + x]);
+            } else {
+                ck_assert_int_eq(0, cpu.screen[64 * y + x]);
+            }
+        }
+    }
+}
+END_TEST
+
+START_TEST(test_screen_clear_row)
+{
+    cpu.esm = 0;
+    memset(cpu.screen, 1, sizeof(cpu.screen));
+    screen_clear_row(&cpu, 6);
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 64; x++) {
+            if (y == 6) {
+                ck_assert_int_eq(0, cpu.screen[64 * y + x]);
+            } else {
+                ck_assert_int_ne(0, cpu.screen[64 * y + x]);
+            }
+        }
+    }
+}
+END_TEST
+
+START_TEST(test_screen_get_pixel)
+{
+    cpu.esm = 0;
+    memset(cpu.screen, 0, sizeof (cpu.screen));
+    cpu.screen[64 * 10 + 10] = 1;
+    cpu.screen[64 * 20 + 20] = 1;
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 64; x++) {
+            if (x == 10 && y == 10) {
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
+            } else if (x == 20 && y == 20) {
+                ck_assert_int_ne(0, screen_get_pixel(&cpu, x, y));
+            } else {
+                ck_assert_int_eq(0, screen_get_pixel(&cpu, x, y));
+            }
+        }
+    }
+}
+END_TEST
+
+START_TEST(test_screen_set_pixel)
+{
+    cpu.esm = 0;
+    memset(cpu.screen, 0, sizeof(cpu.screen));
+    screen_set_pixel(&cpu, 10, 10);
+    screen_set_pixel(&cpu, 20, 20);
+    for (int y = 0; y < 32; y++) {
+        for (int x = 0; x < 64; x++) {
+            if (x == 10 && y == 10) {
+                ck_assert_int_ne(0, cpu.screen[64 * y + x]);
+            } else if (x == 20 && y == 20) {
+                ck_assert_int_ne(0, cpu.screen[64 * y + x]);
+            } else {
+                ck_assert_int_eq(0, cpu.screen[64 * y + x]);
+            }
+        }
+    }
+}
+END_TEST
+
+START_TEST(test_screen_clear_pixel)
+{
+    cpu.esm = 0;
+    memset(cpu.screen, 0, sizeof (cpu.screen));
+    cpu.screen[64 * 10 + 10] = 1;
+    cpu.screen[64 * 20 + 20] = 1;
+    screen_clear_pixel(&cpu, 10, 10);
+    screen_clear_pixel(&cpu, 20, 20);
+    ck_assert_int_eq(0, cpu.screen[64 * 10 + 10]);
+    ck_assert_int_eq(0, cpu.screen[64 * 20 + 20]);
+}
+END_TEST
+
+static TCase*
+tcase_screen_fill_column()
+{
+    TCase* tcase = setup_tcase("screen_fill_column()");
+    tcase_add_test(tcase, test_screen_fill_column);
+    return tcase;
+}
+
+static TCase*
+tcase_screen_clear_column()
+{
+    TCase* tcase = setup_tcase("screen_clear_column()");
+    tcase_add_test(tcase, test_screen_clear_column);
+    return tcase;
+}
+
+static TCase*
+tcase_screen_fill_row()
+{
+    TCase* tcase = setup_tcase("screen_fill_row()");
+    tcase_add_test(tcase, test_screen_fill_row);
+    return tcase;
+}
+
+static TCase*
+tcase_screen_clear_row()
+{
+    TCase* tcase = setup_tcase("screen_clear_row()");
+    tcase_add_test(tcase, test_screen_clear_row);
+    return tcase;
+}
+
+static TCase*
+tcase_screen_get_pixel()
+{
+    TCase* tcase = setup_tcase("screen_get_pixel()");
+    tcase_add_test(tcase, test_screen_get_pixel);
+    return tcase;
+}
+
+static TCase*
+tcase_screen_set_pixel()
+{
+    TCase* tcase = setup_tcase("screen_set_pixel()");
+    tcase_add_test(tcase, test_screen_set_pixel);
+    return tcase;
+}
+
+static TCase*
+tcase_screen_clear_pixel()
+{
+    TCase* tcase = setup_tcase("screen_clear_pixel()");
+    tcase_add_test(tcase, test_screen_clear_pixel);
+    return tcase;
+}
+
+Suite*
+create_screen_suite()
+{
+    Suite* suite = suite_create("Screen management");
+    suite_add_tcase(suite, tcase_screen_fill_column());
+    suite_add_tcase(suite, tcase_screen_clear_column());
+    suite_add_tcase(suite, tcase_screen_fill_row());
+    suite_add_tcase(suite, tcase_screen_clear_row());
+    suite_add_tcase(suite, tcase_screen_get_pixel());
+    suite_add_tcase(suite, tcase_screen_set_pixel());
+    suite_add_tcase(suite, tcase_screen_clear_pixel());
+    return suite;
+}

--- a/tests/test.c
+++ b/tests/test.c
@@ -21,9 +21,13 @@
 extern Suite*
 create_chip8_opcodes_suite();
 
+extern Suite*
+create_superchip_opcodes_suite();
+
 int main(int argc, char** argv)
 {
     SRunner* runner = srunner_create(create_chip8_opcodes_suite());
+    srunner_add_suite(runner, create_superchip_opcodes_suite());
     srunner_run_all(runner, CK_VERBOSE);
     int failed = srunner_ntests_failed(runner);
     srunner_free(runner);

--- a/tests/test.c
+++ b/tests/test.c
@@ -24,10 +24,14 @@ create_chip8_opcodes_suite();
 extern Suite*
 create_superchip_opcodes_suite();
 
+extern Suite*
+create_screen_suite();
+
 int main(int argc, char** argv)
 {
     SRunner* runner = srunner_create(create_chip8_opcodes_suite());
     srunner_add_suite(runner, create_superchip_opcodes_suite());
+    srunner_add_suite(runner, create_screen_suite());
     srunner_run_all(runner, CK_VERBOSE);
     int failed = srunner_ntests_failed(runner);
     srunner_free(runner);

--- a/tests/test.c
+++ b/tests/test.c
@@ -19,11 +19,11 @@
 #include <check.h>
 
 extern Suite*
-create_opcodes_suite();
+create_chip8_opcodes_suite();
 
 int main(int argc, char** argv)
 {
-    SRunner* runner = srunner_create(create_opcodes_suite());
+    SRunner* runner = srunner_create(create_chip8_opcodes_suite());
     srunner_run_all(runner, CK_VERBOSE);
     int failed = srunner_ntests_failed(runner);
     srunner_free(runner);


### PR DESCRIPTION
SUPER-CHIP is an extended instruction set based on the original CHIP-8 emulator designed back in 1991 for HP48 calculators. It is possible to emulate SUPER-CHIP and there are ROMs using the SCHIP format.

This pull request will introduce support for SUPER-CHIP to the already existing CHIP-8 emulator, implementing new opcodes. SCHIP is backwards compatible so already existing CHIP-8 games should still work.
- [x] **Document how SUPER-CHIP works.** SCHIP is an extension and the documentation is more sparse. A document containing the more information I can find, the better.
- [x] **Develop test cases and examples made to test the emulator.** I said I was going to do this on my own before working in the actual emulator so that I don't have to showcase the unit tests in my livestream playlist.
- [x] **Implement the opcodes.** This is the most important part and the part that you will see in the livestream playlist.
- [x] **Verify that the opcodes work.** This is also important because nobody will want to use an emulator that doesn't work.

Useful documentation:
- **[My homemade documentation](https://github.com/danirod/chip8/blob/devel-0.2/doc/schip8.txt)**. Written after reading the documents below.
- **[S-CHIP 1.0](https://groups.google.com/forum/#!msg/comp.sys.handhelds/RuzVNccds2Q/TcvLEWuY9scJ) and [S-CHIP 1.1](https://groups.google.com/forum/#!msg/comp.sys.handhelds/sDY9zFb6KUo/JcYBK2_yerMJ) specifications (1991)**. S-CHIP 1.1 added scrolling.
- **[Cowgod's CHIP-8 reference](http://devernay.free.fr/hacks/chip8/C8TECH10.HTM)**. You must never forget this document, it documents CHIP-8.
- Example [games](http://www.chip8.com/?page=85) and [demos](http://www.chip8.com/?page=89) for the S-CHIP.
- [Aditional documentation](http://www.chip8.com/?page=82) for the S-CHIP.
